### PR TITLE
Feature/pori 502 pathauto aliases

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -74,7 +74,8 @@
         "drupal/migrate_source_jsonpath": "1.x-dev",
         "drupal/context": "^4.0@beta",
         "drupal/empty_page": "^2.0",
-        "drupal/simple_gmap": "^1.4"
+        "drupal/simple_gmap": "^1.4",
+        "drupal/pathauto": "^1.4"
     },
     "require-dev": {
         "codeception/codeception": "^2.2",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bee3365a0e212a87512710f649e2e4f2",
+    "content-hash": "f3629e52d1163c40992eed1ab7ab5bec",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3208,6 +3208,99 @@
             "time": "2019-05-08T16:00:58+00:00"
         },
         {
+            "name": "drupal/ctools",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/ctools.git",
+                "reference": "8.x-3.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ctools-8.x-3.2.zip",
+                "reference": "8.x-3.2",
+                "shasum": "d6da87239b64ba708a5977e7b33b1e009e36b091"
+            },
+            "require": {
+                "drupal/core": "^8.5"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.2",
+                    "datestamp": "1550728386",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Kris Vanderwater (EclipseGc)",
+                    "homepage": "https://www.drupal.org/u/eclipsegc",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jakob Perry (japerry)",
+                    "homepage": "https://www.drupal.org/u/japerry",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Tim Plunkett (tim.plunkett)",
+                    "homepage": "https://www.drupal.org/u/timplunkett",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "James Gilliland (neclimdul)",
+                    "homepage": "https://www.drupal.org/u/neclimdul",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Daniel Wehner (dawehner)",
+                    "homepage": "https://www.drupal.org/u/dawehner",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "joelpittet",
+                    "homepage": "https://www.drupal.org/user/160302"
+                },
+                {
+                    "name": "merlinofchaos",
+                    "homepage": "https://www.drupal.org/user/26979"
+                },
+                {
+                    "name": "neclimdul",
+                    "homepage": "https://www.drupal.org/user/48673"
+                },
+                {
+                    "name": "sdboyer",
+                    "homepage": "https://www.drupal.org/user/146719"
+                },
+                {
+                    "name": "sun",
+                    "homepage": "https://www.drupal.org/user/54136"
+                },
+                {
+                    "name": "tim.plunkett",
+                    "homepage": "https://www.drupal.org/user/241634"
+                }
+            ],
+            "description": "Provides a number of utility and helper APIs for Drupal developers and site builders.",
+            "homepage": "https://www.drupal.org/project/ctools",
+            "support": {
+                "source": "http://cgit.drupalcode.org/ctools",
+                "issues": "https://www.drupal.org/project/issues/ctools"
+            }
+        },
+        {
             "name": "drupal/elasticsearch_helper",
             "version": "dev-5.x",
             "source": {
@@ -3751,6 +3844,67 @@
             }
         },
         {
+            "name": "drupal/pathauto",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/pathauto.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "ddfb047ae04ca2ddf475d65f6c09bceb44169e25"
+            },
+            "require": {
+                "drupal/core": "^8.5",
+                "drupal/ctools": "*",
+                "drupal/token": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1554239887",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Freso",
+                    "homepage": "https://www.drupal.org/user/27504"
+                },
+                {
+                    "name": "greggles",
+                    "homepage": "https://www.drupal.org/user/36762"
+                }
+            ],
+            "description": "Provides a mechanism for modules to automatically generate aliases for the content they manage.",
+            "homepage": "https://www.drupal.org/project/pathauto",
+            "support": {
+                "source": "https://git.drupalcode.org/project/pathauto"
+            }
+        },
+        {
             "name": "drupal/simple_gmap",
             "version": "1.4.0",
             "source": {
@@ -4073,6 +4227,73 @@
             "support": {
                 "source": "https://cgit.drupalcode.org/taxonomy_multidelete_terms",
                 "issues": "https://www.drupal.org/project/issues/taxonomy_multidelete_terms"
+            }
+        },
+        {
+            "name": "drupal/token",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/token.git",
+                "reference": "8.x-1.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.5.zip",
+                "reference": "8.x-1.5",
+                "shasum": "6382a7e1aabbd8246f1117a26bf4916d285b401d"
+            },
+            "require": {
+                "drupal/core": "^8.5"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.5",
+                    "datestamp": "1537557481",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "eaton",
+                    "homepage": "https://www.drupal.org/user/16496"
+                },
+                {
+                    "name": "fago",
+                    "homepage": "https://www.drupal.org/user/16747"
+                },
+                {
+                    "name": "greggles",
+                    "homepage": "https://www.drupal.org/user/36762"
+                },
+                {
+                    "name": "mikeryan",
+                    "homepage": "https://www.drupal.org/user/4420"
+                }
+            ],
+            "description": "Provides a user interface for the Token API and some missing core tokens.",
+            "homepage": "https://www.drupal.org/project/token",
+            "support": {
+                "source": "https://git.drupalcode.org/project/token"
             }
         },
         {

--- a/drupal/sync/core.entity_view_mode.block.token.yml
+++ b/drupal/sync/core.entity_view_mode.block.token.yml
@@ -1,0 +1,10 @@
+uuid: 844a7d65-2574-471d-b648-d2a0583bc131
+langcode: fi
+status: true
+dependencies:
+  module:
+    - block
+id: block.token
+label: Token
+targetEntityType: block
+cache: true

--- a/drupal/sync/core.entity_view_mode.block_content.token.yml
+++ b/drupal/sync/core.entity_view_mode.block_content.token.yml
@@ -1,0 +1,10 @@
+uuid: e2c149e4-6f5c-4860-9558-4305f0b618f5
+langcode: fi
+status: true
+dependencies:
+  module:
+    - block_content
+id: block_content.token
+label: Token
+targetEntityType: block_content
+cache: true

--- a/drupal/sync/core.entity_view_mode.comment.token.yml
+++ b/drupal/sync/core.entity_view_mode.comment.token.yml
@@ -1,0 +1,10 @@
+uuid: b648c8b2-42ae-4653-8bdf-2157d75766bc
+langcode: fi
+status: true
+dependencies:
+  module:
+    - comment
+id: comment.token
+label: Token
+targetEntityType: comment
+cache: true

--- a/drupal/sync/core.entity_view_mode.contact_message.token.yml
+++ b/drupal/sync/core.entity_view_mode.contact_message.token.yml
@@ -1,0 +1,10 @@
+uuid: 5c201519-5fcb-4b16-a24b-44072eed481a
+langcode: fi
+status: true
+dependencies:
+  module:
+    - contact
+id: contact_message.token
+label: Token
+targetEntityType: contact_message
+cache: true

--- a/drupal/sync/core.entity_view_mode.entity_subqueue.token.yml
+++ b/drupal/sync/core.entity_view_mode.entity_subqueue.token.yml
@@ -1,0 +1,10 @@
+uuid: e3fb90bb-1d4a-4bd3-b8b6-5caee617200c
+langcode: fi
+status: true
+dependencies:
+  module:
+    - entityqueue
+id: entity_subqueue.token
+label: Token
+targetEntityType: entity_subqueue
+cache: true

--- a/drupal/sync/core.entity_view_mode.file.token.yml
+++ b/drupal/sync/core.entity_view_mode.file.token.yml
@@ -1,0 +1,10 @@
+uuid: b11cbd35-979b-410b-a46d-cf8966e89f08
+langcode: fi
+status: true
+dependencies:
+  module:
+    - file
+id: file.token
+label: Token
+targetEntityType: file
+cache: true

--- a/drupal/sync/core.entity_view_mode.menu_link_content.token.yml
+++ b/drupal/sync/core.entity_view_mode.menu_link_content.token.yml
@@ -1,0 +1,10 @@
+uuid: ef930e59-56cf-4f83-83cb-b9a63b1f1992
+langcode: fi
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.token
+label: Token
+targetEntityType: menu_link_content
+cache: true

--- a/drupal/sync/core.entity_view_mode.node.token.yml
+++ b/drupal/sync/core.entity_view_mode.node.token.yml
@@ -1,0 +1,10 @@
+uuid: feb059ab-3171-4502-af8d-28673690ff21
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: node.token
+label: Token
+targetEntityType: node
+cache: true

--- a/drupal/sync/core.entity_view_mode.shortcut.token.yml
+++ b/drupal/sync/core.entity_view_mode.shortcut.token.yml
@@ -1,0 +1,10 @@
+uuid: 24b59628-829e-4649-818c-e7c9f36aa8c6
+langcode: fi
+status: true
+dependencies:
+  module:
+    - shortcut
+id: shortcut.token
+label: Token
+targetEntityType: shortcut
+cache: true

--- a/drupal/sync/core.entity_view_mode.taxonomy_term.token.yml
+++ b/drupal/sync/core.entity_view_mode.taxonomy_term.token.yml
@@ -1,0 +1,10 @@
+uuid: 486bc14b-7453-41af-aa0a-ba67cd333995
+langcode: fi
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.token
+label: Token
+targetEntityType: taxonomy_term
+cache: true

--- a/drupal/sync/core.entity_view_mode.tour.token.yml
+++ b/drupal/sync/core.entity_view_mode.tour.token.yml
@@ -1,0 +1,10 @@
+uuid: 7528f7ce-f7ac-4602-92f8-e05faed4cfb1
+langcode: fi
+status: true
+dependencies:
+  module:
+    - tour
+id: tour.token
+label: Token
+targetEntityType: tour
+cache: true

--- a/drupal/sync/core.entity_view_mode.user.token.yml
+++ b/drupal/sync/core.entity_view_mode.user.token.yml
@@ -1,0 +1,10 @@
+uuid: 056d1130-8a26-489c-b388-3f8f940c990e
+langcode: fi
+status: true
+dependencies:
+  module:
+    - user
+id: user.token
+label: Token
+targetEntityType: user
+cache: true

--- a/drupal/sync/core.extension.yml
+++ b/drupal/sync/core.extension.yml
@@ -15,6 +15,7 @@ module:
   contact: 0
   context: 0
   contextual: 0
+  ctools: 0
   datetime: 0
   datetime_range: 0
   dblog: 0
@@ -65,6 +66,7 @@ module:
   taxonomy: 0
   taxonomy_multidelete_terms: 0
   text: 0
+  token: 0
   toolbar: 0
   tour: 0
   twig_tweak: 0
@@ -73,6 +75,7 @@ module:
   views_ui: 0
   warden: 0
   menu_link_content: 1
+  pathauto: 1
   content_translation: 10
   elasticsearch_helper: 10
   views: 10

--- a/drupal/sync/core.extension.yml
+++ b/drupal/sync/core.extension.yml
@@ -52,6 +52,7 @@ module:
   path: 0
   pori_events_link_formatter: 0
   pori_harrastukset: 0
+  pori_pathauto: 0
   quickedit: 0
   rdf: 0
   search: 0

--- a/drupal/sync/pathauto.pattern.default.yml
+++ b/drupal/sync/pathauto.pattern.default.yml
@@ -1,0 +1,14 @@
+uuid: fff057f5-8c1e-4309-80af-e4837c0ba200
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: default
+label: Default
+type: 'canonical_entities:node'
+pattern: '[node:title]'
+selection_criteria: {  }
+selection_logic: and
+weight: 0
+relationships: {  }

--- a/drupal/sync/pathauto.pattern.events.yml
+++ b/drupal/sync/pathauto.pattern.events.yml
@@ -1,0 +1,22 @@
+uuid: 39f18d14-ad2e-40bd-81b0-811784c5f4f8
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+id: events
+label: Events
+type: 'canonical_entities:node'
+pattern: '[node:title]-[node:field_start_time:date:custom:Y-m-d]'
+selection_criteria:
+  29c7acac-363e-444a-b637-00e7fb8294f6:
+    id: node_type
+    bundles:
+      event: event
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 29c7acac-363e-444a-b637-00e7fb8294f6
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/drupal/sync/pathauto.settings.yml
+++ b/drupal/sync/pathauto.settings.yml
@@ -1,0 +1,23 @@
+enabled_entity_types:
+  - user
+punctuation:
+  hyphen: 1
+verbose: false
+separator: '-'
+max_length: 100
+max_component_length: 100
+transliterate: true
+reduce_ascii: false
+case: true
+ignore_words: 'a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with'
+update_action: 2
+safe_tokens:
+  - alias
+  - path
+  - join-path
+  - login-url
+  - url
+  - url-brief
+_core:
+  default_config_hash: SwvLp8snyPEExF41CaJJYdPUVomofLqtXvwciHc4cPg
+langcode: fi

--- a/drupal/sync/system.action.pathauto_update_alias_node.yml
+++ b/drupal/sync/system.action.pathauto_update_alias_node.yml
@@ -1,0 +1,16 @@
+uuid: 5fa39ab3-ce79-47bc-9a38-7d203fea80aa
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - node
+  module:
+    - pathauto
+_core:
+  default_config_hash: lno8QThS348UX-kaUsagJtCnuPHKLXYnTQiF_9HSDWA
+id: pathauto_update_alias_node
+label: 'Update URL alias'
+type: node
+plugin: pathauto_update_alias
+configuration: {  }

--- a/drupal/sync/system.action.pathauto_update_alias_user.yml
+++ b/drupal/sync/system.action.pathauto_update_alias_user.yml
@@ -1,0 +1,16 @@
+uuid: 49fdb6ba-15b4-46c4-9742-ef6c9d23b2a2
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - user
+  module:
+    - pathauto
+_core:
+  default_config_hash: x_ok_ZsfA4Xk4B_hVW3O4-3PcNoK57nXLz_Dlletidg
+id: pathauto_update_alias_user
+label: 'Update URL alias'
+type: user
+plugin: pathauto_update_alias
+configuration: {  }

--- a/drupal/web/modules/custom/pori_pathauto/pori_pathauto.info.yml
+++ b/drupal/web/modules/custom/pori_pathauto/pori_pathauto.info.yml
@@ -1,0 +1,7 @@
+name: 'Pori pathauto'
+type: module
+description: 'Pori events site pathauto alterations'
+core: 8.x
+package: 'Pori Events'
+dependencies:
+  - drupal:pathauto

--- a/drupal/web/modules/custom/pori_pathauto/pori_pathauto.module
+++ b/drupal/web/modules/custom/pori_pathauto/pori_pathauto.module
@@ -36,7 +36,7 @@ function pori_pathauto_pathauto_pattern_alter(PathautoPatternInterface $pattern,
     // @todo: Take translations into account.
     if ($node->getType() == 'event') {
       $segment1 = ($node->hasField('field_hobby_is_hobby') && $node->field_hobby_is_hobby->value) ? 'harrastukset': 'tapahtumat';
-      $pattern->setPattern($segment1 . '/[node:title]');
+      $pattern->setPattern($segment1 . '/' . $pattern->getPattern());
     }
   }
 }

--- a/drupal/web/modules/custom/pori_pathauto/pori_pathauto.module
+++ b/drupal/web/modules/custom/pori_pathauto/pori_pathauto.module
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Contains pori_pathauto.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\pathauto\PathautoPatternInterface;
+
+/**
+ * Implements hook_help().
+ */
+function pori_pathauto_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the pori_pathauto module.
+    case 'help.page.pori_pathauto':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Pori events site pathauto alterations for event node type') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Implements hook_pathauto_pattern_alter().
+ */
+function pori_pathauto_pathauto_pattern_alter(PathautoPatternInterface $pattern, array $context) {
+  if ($context['module'] == 'node' && $context['op'] == 'update') {
+    /* @var $node \Drupal\node\NodeInterface */
+    $node = $context['data']['node'];
+
+    // Events pathauto pattern depends on if hobby or not.
+    // @todo: Take translations into account.
+    if ($node->getType() == 'event') {
+      $segment1 = ($node->hasField('field_hobby_is_hobby') && $node->field_hobby_is_hobby->value) ? 'harrastukset': 'tapahtumat';
+      $pattern->setPattern($segment1 . '/[node:title]');
+    }
+  }
+}


### PR DESCRIPTION
This PR adds pathauto configurations:
* By default all nodes get the node title as url alias
* Events get path `harrastukset/node-title-YYYY-MM-DD` or `tapahtumat/node-title-YYYY-MM-DD?` based on field_hobby_is_hobby value

To test, see links to nodes in https://pori-events.dev.wunder.io/ and https://pori-events.dev.wunder.io/harrastukset/