### PR TITLE
Do not render empty urls

### DIFF
--- a/drupal/web/modules/custom/pori_events_link_formatter/src/Plugin/Field/FieldFormatter/LinkFieldFormatter.php
+++ b/drupal/web/modules/custom/pori_events_link_formatter/src/Plugin/Field/FieldFormatter/LinkFieldFormatter.php
@@ -74,12 +74,14 @@ class LinkFieldFormatter extends FormatterBase {
     $label = preg_replace('#^https?://#', '', $item->getValue()['value']);
     $url = $item->getValue()['value'];
 
-    $url_contents = parse_url($url);
+    if ($url != '') {
+      $url_contents = parse_url($url);
 
-    if (!isset($url_contents['scheme'])) {
-      $url = '//' . $item->getValue()['value'];
+      if (!isset($url_contents['scheme'])) {
+        $url = '//' . $item->getValue()['value'];
+      }
+
+      return ['label' => $label, 'url' => $url];
     }
-
-    return ['label' => $label, 'url' => $url];
   }
 }


### PR DESCRIPTION
Prevents these: 
```
[error]  "label" is an invalid render array key Element.php:97
 [error]  "url" is an invalid render array key Element.php:97```
