### PR TITLE
Flush caches for default daterange update after midnight

### DIFF
--- a/conf/develop.yml
+++ b/conf/develop.yml
@@ -59,7 +59,17 @@
         user: nginx
       tags: ['cron']
       when: drupal_web_root is defined
-
+  # Clear caches after midnight because of \Drupal\pori_event_search_defaults\EventSubscriber\EventsDefaultRedirectSubscriber getting stuck there for frontpage request
+    - name: "Daily cache clear"
+      cron:
+        name: "Clear caches"
+        minute: "5"
+        hour: "0"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cr"
+        state: "present"
+        user: nginx
+      tags: ['cron']
+      when: drupal_web_root is defined
 
   vars:
     wkv_site_env: dev

--- a/conf/prod-front.yml
+++ b/conf/prod-front.yml
@@ -50,6 +50,18 @@
         user: nginx
       tags: ['cron']
       when: ansible_eth0.ipv4.address == groups['prod-front'][0] and drupal_web_root is defined
+    # Clear caches after midnight because of \Drupal\pori_event_search_defaults\EventSubscriber\EventsDefaultRedirectSubscriber getting stuck there for frontpage request
+    - name: "Daily cache clear"
+      cron:
+        name: "Clear caches"
+        minute: "5"
+        hour: "0"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cr"
+        state: "present"
+        user: nginx
+      tags: ['cron']
+      when: ansible_eth0.ipv4.address == groups['prod-front'][0] and drupal_web_root is defined
+
 
   vars:
 

--- a/conf/stage.yml
+++ b/conf/stage.yml
@@ -59,6 +59,17 @@
         user: nginx
       tags: ['cron']
       when: drupal_web_root is defined
+    # Clear caches after midnight because of \Drupal\pori_event_search_defaults\EventSubscriber\EventsDefaultRedirectSubscriber getting stuck there for frontpage request
+    - name: "Daily cache clear"
+      cron:
+        name: "Clear caches"
+        minute: "5"
+        hour: "0"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cr"
+        state: "present"
+        user: nginx
+      tags: ['cron']
+      when: drupal_web_root is defined
 
   vars:
     wkv_site_env: stage


### PR DESCRIPTION
Add cache clearing to crontab to ensure caches refresh after midnight to ensure the default date redirect get rebuild.

Even adding cachetags to `\Drupal\pori_event_search_defaultsEventSubscriberEventsDefaultRedirectSubscriber` did not seem to help for frontpage request so used this "last resort" to overcome the issue.