### PR TITLE
Feature/pori 560 date filter range increase

### DIFF
--- a/drupal/web/modules/custom/pori_event_search_defaults/src/EventSubscriber/EventsDefaultRedirectSubscriber.php
+++ b/drupal/web/modules/custom/pori_event_search_defaults/src/EventSubscriber/EventsDefaultRedirectSubscriber.php
@@ -35,7 +35,7 @@ class EventsDefaultRedirectSubscriber implements EventSubscriberInterface {
       // Use millisecond dates like
       // \Drupal\events2elastic\Plugin\Normalizer\NodeNormalizer does..
       $start = 'event_date_from=' . date('U000', $today);
-      $end = 'event_date_to=' . date('U000', strtotime('+5 day', $today));
+      $end = 'event_date_to=' . date('U000', strtotime('+7 day', $today));
 
       // Rewrite to empty url if homepage.
       $url = ($path_matcher->isFrontpage()) ? '' : $url;

--- a/drupal/web/modules/custom/pori_event_search_defaults/src/EventSubscriber/EventsDefaultRedirectSubscriber.php
+++ b/drupal/web/modules/custom/pori_event_search_defaults/src/EventSubscriber/EventsDefaultRedirectSubscriber.php
@@ -35,7 +35,7 @@ class EventsDefaultRedirectSubscriber implements EventSubscriberInterface {
       // Use millisecond dates like
       // \Drupal\events2elastic\Plugin\Normalizer\NodeNormalizer does..
       $start = 'event_date_from=' . date('U000', $today);
-      $end = 'event_date_to=' . date('U000', strtotime('+7 day', $today));
+      $end = 'event_date_to=' . date('U000', strtotime('+6 day', $today));
 
       // Rewrite to empty url if homepage.
       $url = ($path_matcher->isFrontpage()) ? '' : $url;


### PR DESCRIPTION
Default search date filter should be: start date: today - end date: +7 days. (Ex. Monday to Sunday).
Can check on https://pori-events.dev.wunder.io