### PR TITLE
PORISD-161: Patch for google_tag to fix unlinking google_tag.script.js

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -152,6 +152,9 @@
             },
             "drupal/twig_tweak": {
                 "https://www.drupal.org/project/twig_tweak/issues/3137994: imageStyle should return original image path as a fallback": "https://www.drupal.org/files/issues/2021-10-15/3137994-8-imagestyle-fallback-path.patch"
+            },
+            "drupal/google_tag": {
+                "https://www.drupal.org/i/3250315: Error during cache rebuild when assets are stored on NFS": "https://www.drupal.org/files/issues/2022-11-23/3250315-google-tag-nfs-locks-5.patch"
             }
         }
     },


### PR DESCRIPTION
files/google_tag/tapahtumat.pori.fi/google_tag.script.js